### PR TITLE
Add uid as explicit method

### DIFF
--- a/lib/omniauth/strategies/feishu.rb
+++ b/lib/omniauth/strategies/feishu.rb
@@ -17,6 +17,8 @@ module OmniAuth
         user_info_url: "https://open.feishu.cn/open-apis/authen/v1/user_info"
       }
 
+      uid { raw_info['user_id'] }
+
       info do
         {
           name: raw_info['name'],
@@ -26,10 +28,10 @@ module OmniAuth
           avatar_thumb: raw_info['avatar_thumb'],
           avatar_middle: raw_info['avatar_middle'],
           avatar_big: raw_info['avatar_big'],
-          user_id: raw_info['user_id'], 
-          union_id: raw_info['union_id'], 
-          open_id: raw_info['open_id'], 
-          en_name: raw_info['en_name'], 
+          user_id: raw_info['user_id'],
+          union_id: raw_info['union_id'],
+          open_id: raw_info['open_id'],
+          en_name: raw_info['en_name'],
           app_access_token: @app_access_token
         }
       end


### PR DESCRIPTION
Now we can call `provider.uid` to get user id directly.